### PR TITLE
feat: honor system color scheme

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -27,8 +27,8 @@
   flex-direction: column;
   align-items: center;
   gap: 0.5rem;
-  background: inherit;
-  border-bottom: 1px solid #e0e0e0;
+  background: var(--color-bg-secondary);
+  border-bottom: 1px solid var(--color-border-subtle);
 }
 
 /* Graph area takes remaining space */
@@ -45,8 +45,8 @@
   grid-column: 2;
   width: 240px;
   padding: 10px;
-  border-left: 1px solid #e0e0e0;
-  background: inherit;
+  border-left: 1px solid var(--color-border-subtle);
+  background: var(--color-bg-secondary);
   overflow-y: auto;
 }
 
@@ -62,7 +62,7 @@
     grid-column: 1;
     width: auto;
     border-left: none;
-    border-bottom: 1px solid #e0e0e0;
+    border-bottom: 1px solid var(--color-border-subtle);
     padding: 0.5rem 1rem;
   }
   
@@ -83,23 +83,25 @@
   text-decoration: none;
   font-size: 0.9rem;
   padding: 0.5rem 1rem;
-  border: 1px solid #ccc;
+  border: 1px solid var(--color-border-subtle);
   border-radius: 4px;
-  background: #f8f9fa;
+  background: var(--color-surface-elevated);
   display: inline-block;
   transition: all 0.2s ease;
 }
 
 .app-header .documentation-link:hover {
-  background: #e9ecef;
+  background: var(--color-surface-hover);
 }
 
 .app-header select {
   margin: 0;
   padding: 0.5rem;
-  border: 1px solid #ccc;
+  border: 1px solid var(--color-border-subtle);
   border-radius: 4px;
   font-size: 0.9rem;
+  background: var(--color-surface-elevated);
+  color: var(--color-text-primary);
 }
 
 /* Ensure GraphView component takes up space */

--- a/frontend/src/config/theme.ts
+++ b/frontend/src/config/theme.ts
@@ -13,6 +13,8 @@ import {
 
 const { colors, spacing, fontSize, radius, shadow } = tokens;
 
+const withCssVar = (name: string, fallback: string) => `var(${name}, ${fallback})`;
+
 /**
  * Level color generator function
  * Generates consistent colors for hierarchy levels
@@ -36,27 +38,27 @@ export const theme = {
   // Semantic colors derived from tokens
   colors: {
     background: {
-      primary: colors.legacy.white,
-      secondary: colors.gray[50],
-      overlay: 'rgba(0, 0, 0, 0.3)',
+      primary: withCssVar('--color-bg-primary', colors.legacy.white),
+      secondary: withCssVar('--color-bg-secondary', colors.gray[50]),
+      overlay: withCssVar('--color-overlay', 'rgba(0, 0, 0, 0.3)'),
       error: '#fef2f2',
       info: '#f8fafc',
     },
-    
+
     border: {
-      default: colors.gray[300],
-      light: colors.gray[200],
-      dark: colors.legacy.borderDefault,
+      default: withCssVar('--color-border-subtle', colors.gray[300]),
+      light: withCssVar('--color-border-subtle', colors.gray[200]),
+      dark: withCssVar('--color-border-strong', colors.legacy.borderDefault),
       active: colors.primary[500],
       expanded: colors.warning[700],
       error: colors.danger[500],
     },
-    
+
     text: {
-      primary: colors.legacy.textDefault,
-      secondary: colors.gray[600],
-      muted: colors.legacy.nodeDefault,
-      inverse: colors.legacy.white,
+      primary: withCssVar('--color-text-primary', colors.legacy.textDefault),
+      secondary: withCssVar('--color-text-secondary', colors.gray[600]),
+      muted: withCssVar('--color-text-secondary', colors.legacy.nodeDefault),
+      inverse: withCssVar('--color-text-inverse', colors.legacy.white),
       disabled: colors.gray[300],
       error: colors.danger[600],
       success: colors.success[600],
@@ -182,7 +184,7 @@ export const theme = {
         width: '100%',
         padding: spacing.scale(1), // 4px
         marginBottom: spacing.scale(3), // 12px
-        border: `1px solid ${colors.gray[300]}`,
+        border: `1px solid ${withCssVar('--color-border-subtle', colors.gray[300])}`,
         borderRadius: radius.sm,
         fontSize: fontSize.sm,
       },
@@ -190,7 +192,7 @@ export const theme = {
         display: 'block',
         marginBottom: spacing.scale(1), // 4px
         fontWeight: 500,
-        color: colors.legacy.textDefault,
+        color: withCssVar('--color-text-primary', colors.legacy.textDefault),
       },
       error: {
         color: colors.danger[600],
@@ -219,8 +221,8 @@ export const theme = {
     },
     
     contextMenu: {
-      background: colors.legacy.white,
-      border: colors.gray[300],
+      background: withCssVar('--color-surface-elevated', colors.legacy.white),
+      border: withCssVar('--color-border-subtle', colors.gray[300]),
       shadow: shadow.lg,
       borderRadius: radius.base,
       item: {
@@ -232,8 +234,8 @@ export const theme = {
     },
     
     modal: {
-      overlay: 'rgba(0,0,0,0.3)',
-      background: colors.legacy.white,
+      overlay: withCssVar('--color-overlay', 'rgba(0,0,0,0.3)'),
+      background: withCssVar('--color-surface-elevated', colors.legacy.white),
       shadow: shadow.xl,
       borderRadius: radius.base,
       padding: spacing.scale(5), // 20px
@@ -248,12 +250,12 @@ export const theme = {
     },
     
     drawer: {
-      background: colors.legacy.white,
-      border: colors.gray[300],
+      background: withCssVar('--color-surface-elevated', colors.legacy.white),
+      border: withCssVar('--color-border-subtle', colors.gray[300]),
       shadow: '-2px 0 5px rgba(0,0,0,0.1)',
       borderRadius: radius.none,
       header: {
-        borderBottom: colors.gray[200],
+        borderBottom: withCssVar('--color-border-subtle', colors.gray[200]),
         padding: spacing.scale(3), // 12px
       },
       tab: {
@@ -269,28 +271,28 @@ export const theme = {
     },
     
     settingsIcon: {
-      background: 'rgba(255, 255, 255, 0.95)',
-      backgroundHover: 'rgba(255, 255, 255, 1)',
-      border: colors.gray[300],
+      background: withCssVar('--color-floating-surface', 'rgba(255, 255, 255, 0.95)'),
+      backgroundHover: withCssVar('--color-floating-surface-hover', 'rgba(255, 255, 255, 1)'),
+      border: withCssVar('--color-border-subtle', colors.gray[300]),
       shadow: shadow.base,
       borderRadius: radius.full,
     },
-    
+
     settingsModal: {
-      overlay: 'rgba(0,0,0,0.3)',
-      background: colors.legacy.white,
+      overlay: withCssVar('--color-overlay', 'rgba(0,0,0,0.3)'),
+      background: withCssVar('--color-surface-elevated', colors.legacy.white),
       shadow: shadow['2xl'],
       borderRadius: radius.lg,
       maxWidth: 800,
       header: {
-        borderBottom: colors.gray[200],
+        borderBottom: withCssVar('--color-border-subtle', colors.gray[200]),
         padding: spacing.scale(6), // 24px
       },
       content: {
         padding: spacing.scale(5), // 20px
       },
       section: {
-        borderBottom: colors.gray[200],
+        borderBottom: withCssVar('--color-border-subtle', colors.gray[200]),
         padding: spacing.scale(3), // 12px
       },
       tab: {
@@ -315,11 +317,11 @@ export const theme = {
         },
         title: {
           margin: '0 0 20px 0',
-          color: colors.legacy.textDefault,
+          color: withCssVar('--color-text-primary', colors.legacy.textDefault),
         },
         subtitle: {
           margin: '0 0 30px 0',
-          color: colors.gray[600],
+          color: withCssVar('--color-text-secondary', colors.gray[600]),
           fontSize: fontSize.sm,
         },
         inputContainer: {
@@ -329,7 +331,7 @@ export const theme = {
         input: {
           width: '100%',
           padding: '12px 40px 12px 16px',
-          border: `1px solid ${colors.gray[300]}`,
+          border: `1px solid ${withCssVar('--color-border-subtle', colors.gray[300])}`,
           borderRadius: radius.sm,
           fontSize: fontSize.sm,
           boxSizing: 'border-box' as const,
@@ -342,7 +344,7 @@ export const theme = {
           background: 'none',
           border: 'none',
           cursor: 'pointer',
-          color: colors.gray[600],
+          color: withCssVar('--color-text-secondary', colors.gray[600]),
           fontSize: spacing.scale(4), // 16px
           padding: spacing.scale(1), // 4px
           display: 'flex',
@@ -368,7 +370,7 @@ export const theme = {
         },
         sectionTitle: {
           margin: '0 0 12px 0',
-          color: colors.legacy.textDefault,
+          color: withCssVar('--color-text-primary', colors.legacy.textDefault),
         },
         buttonGroup: {
           display: 'flex',
@@ -389,7 +391,7 @@ export const theme = {
         },
         resultItem: {
           padding: spacing.scale(3), // 12px
-          border: `1px solid ${colors.gray[200]}`,
+          border: `1px solid ${withCssVar('--color-border-subtle', colors.gray[200])}`,
           borderRadius: radius.sm,
           marginBottom: spacing.scale(2), // 8px
           fontSize: fontSize.sm,
@@ -401,23 +403,23 @@ export const theme = {
           marginBottom: spacing.scale(1), // 4px
         },
         resultMeta: {
-          color: colors.gray[600],
+          color: withCssVar('--color-text-secondary', colors.gray[600]),
           fontSize: fontSize.xs,
         },
         expandButton: {
           background: 'none',
-          border: `1px solid ${colors.gray[300]}`,
+          border: `1px solid ${withCssVar('--color-border-subtle', colors.gray[300])}`,
           borderRadius: 3,
           padding: '2px 6px',
           fontSize: 11,
           cursor: 'pointer',
-          color: colors.gray[600],
+          color: withCssVar('--color-text-secondary', colors.gray[600]),
         },
         expandedDetails: {
           marginTop: spacing.scale(2), // 8px
           padding: spacing.scale(3), // 12px
-          background: colors.gray[50],
-          border: `1px solid ${colors.gray[200]}`,
+          background: withCssVar('--color-bg-secondary', colors.gray[50]),
+          border: `1px solid ${withCssVar('--color-border-subtle', colors.gray[200])}`,
           borderRadius: radius.sm,
           fontSize: fontSize.xs,
         },
@@ -437,7 +439,7 @@ export const theme = {
         },
         title: {
           margin: 0,
-          color: colors.legacy.textDefault,
+          color: withCssVar('--color-text-primary', colors.legacy.textDefault),
         },
         actionGroup: {
           display: 'flex',
@@ -445,25 +447,25 @@ export const theme = {
         },
         modeIndicator: {
           fontSize: fontSize.xs,
-          color: colors.gray[600],
+          color: withCssVar('--color-text-secondary', colors.gray[600]),
           marginBottom: spacing.scale(2), // 8px
         },
         createForm: {
           marginBottom: spacing.scale(4), // 16px
           padding: spacing.scale(4), // 16px
-          border: `1px solid ${colors.gray[200]}`,
+          border: `1px solid ${withCssVar('--color-border-subtle', colors.gray[200])}`,
           borderRadius: radius.sm,
-          background: colors.gray[50],
+          background: withCssVar('--color-bg-secondary', colors.gray[50]),
         },
         createFormTitle: {
           margin: '0 0 12px 0',
-          color: colors.legacy.textDefault,
+          color: withCssVar('--color-text-primary', colors.legacy.textDefault),
           fontSize: fontSize.sm,
         },
         createFormInput: {
           width: '100%',
           padding: '8px 12px',
-          border: `1px solid ${colors.gray[300]}`,
+          border: `1px solid ${withCssVar('--color-border-subtle', colors.gray[300])}`,
           borderRadius: radius.sm,
           fontSize: fontSize.sm,
           boxSizing: 'border-box' as const,
@@ -478,7 +480,7 @@ export const theme = {
         },
         tenantItem: {
           padding: spacing.scale(4), // 16px
-          border: `1px solid ${colors.gray[200]}`,
+          border: `1px solid ${withCssVar('--color-border-subtle', colors.gray[200])}`,
           borderRadius: radius.sm,
           marginBottom: spacing.scale(3), // 12px
         },
@@ -493,7 +495,7 @@ export const theme = {
           fontSize: fontSize.sm,
         },
         tenantNamespace: {
-          color: colors.gray[600],
+          color: withCssVar('--color-text-secondary', colors.gray[600]),
           fontSize: fontSize.xs,
         },
         tenantActions: {
@@ -512,7 +514,7 @@ export const theme = {
         },
         tenantMeta: {
           fontSize: fontSize.xs,
-          color: colors.gray[600],
+          color: withCssVar('--color-text-secondary', colors.gray[600]),
         },
         actionButton: {
           padding: '4px 8px',
@@ -524,27 +526,27 @@ export const theme = {
         schemaButton: {
           padding: '2px 6px',
           background: 'transparent',
-          border: `1px solid ${colors.gray[300]}`,
+          border: `1px solid ${withCssVar('--color-border-subtle', colors.gray[300])}`,
           borderRadius: 3,
           fontSize: 11,
           cursor: 'pointer',
-          color: colors.legacy.textDefault,
+          color: withCssVar('--color-text-primary', colors.legacy.textDefault),
           display: 'flex',
           alignItems: 'center',
           gap: spacing.scale(1), // 4px
         },
       },
       schema: {
-        overlay: 'rgba(0,0,0,0.5)',
-        background: colors.legacy.white,
+        overlay: withCssVar('--color-overlay', 'rgba(0,0,0,0.5)'),
+        background: withCssVar('--color-surface-elevated', colors.legacy.white),
         shadow: '0 10px 25px rgba(0,0,0,0.3)',
         borderRadius: radius.lg,
         width: '80%',
         maxWidth: 800,
         height: '80%',
         header: {
-          borderBottom: `1px solid ${colors.gray[200]}`,
-          background: colors.gray[50],
+          borderBottom: `1px solid ${withCssVar('--color-border-subtle', colors.gray[200])}`,
+          background: withCssVar('--color-bg-secondary', colors.gray[50]),
           padding: '16px 20px',
         },
         title: {
@@ -555,7 +557,7 @@ export const theme = {
         subtitle: {
           margin: '4px 0 0 0',
           fontSize: fontSize.sm,
-          color: colors.gray[600],
+          color: withCssVar('--color-text-secondary', colors.gray[600]),
         },
         headerActions: {
           display: 'flex',
@@ -567,8 +569,8 @@ export const theme = {
           padding: spacing.scale(5), // 20px
         },
         codeBlock: {
-          background: colors.gray[50],
-          border: `1px solid ${colors.gray[200]}`,
+          background: withCssVar('--color-bg-secondary', colors.gray[50]),
+          border: `1px solid ${withCssVar('--color-border-subtle', colors.gray[200])}`,
           borderRadius: radius.sm,
           padding: spacing.scale(4), // 16px
           fontSize: 13,
@@ -576,7 +578,7 @@ export const theme = {
           overflow: 'auto' as const,
           margin: 0,
           fontFamily: 'Monaco, Menlo, "Ubuntu Mono", monospace',
-          color: colors.legacy.textDefault,
+          color: withCssVar('--color-text-primary', colors.legacy.textDefault),
           whiteSpace: 'pre-wrap' as const,
           wordBreak: 'break-word' as const,
         },
@@ -585,7 +587,7 @@ export const theme = {
           padding: spacing.scale(10), // 40px
         },
         loadingText: {
-          color: colors.gray[600],
+          color: withCssVar('--color-text-secondary', colors.gray[600]),
         },
       },
     },

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2,26 +2,36 @@
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
-
   color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
-  
-  /* border: 1px dashed orange; /* Debug border - REMOVED */
-  /* background-color: #fff8dc; /* Keep Debug background for now - REMOVED */
+
+  /* Theming variables */
+  --color-bg-primary: #ffffff;
+  --color-bg-secondary: #f3f4f6;
+  --color-surface-elevated: #f8f9fa;
+  --color-surface-hover: #e9ecef;
+  --color-border-subtle: #e5e7eb;
+  --color-border-strong: #cbd5e1;
+  --color-text-primary: #213547;
+  --color-text-secondary: #475569;
+  --color-text-inverse: #0f172a;
+  --color-link: #646cff;
+  --color-link-hover: #535bf2;
+  --color-button-bg: #f9f9f9;
+  --color-floating-surface: rgba(255, 255, 255, 0.95);
+  --color-floating-surface-hover: rgba(255, 255, 255, 1);
+  --color-overlay: rgba(15, 23, 42, 0.45);
 }
 
 a {
   font-weight: 500;
-  color: #646cff;
+  color: var(--color-link);
   text-decoration: inherit;
 }
 a:hover {
-  color: #535bf2;
+  color: var(--color-link-hover);
 }
 
 /* Constrain body */
@@ -32,6 +42,8 @@ body {
   overflow: hidden; /* Prevent body scrollbars */
   display: flex; /* Use flexbox */
   flex-direction: column; /* Stack children vertically */
+  color: var(--color-text-primary);
+  background-color: var(--color-bg-primary);
   /* place-items: center; Removed */
   /* min-width: 320px; Removed */
   /* min-height: 100vh; Replaced by height: 100vh */
@@ -49,7 +61,7 @@ button {
   font-size: 1em;
   font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
+  background-color: var(--color-button-bg);
   cursor: pointer;
   transition: border-color 0.25s;
 }
@@ -62,15 +74,22 @@ button:hover {
     outline-offset: 2px;
   }
 
-@media (prefers-color-scheme: light) {
+@media (prefers-color-scheme: dark) {
   :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
+    --color-bg-primary: #0f172a;
+    --color-bg-secondary: #111827;
+    --color-surface-elevated: #1f2937;
+    --color-surface-hover: #273449;
+    --color-border-subtle: rgba(148, 163, 184, 0.35);
+    --color-border-strong: rgba(148, 163, 184, 0.55);
+    --color-text-primary: #e2e8f0;
+    --color-text-secondary: #cbd5f5;
+    --color-text-inverse: #0f172a;
+    --color-link: #a5b4fc;
+    --color-link-hover: #c7d2fe;
+    --color-button-bg: rgba(148, 163, 184, 0.16);
+    --color-floating-surface: rgba(15, 23, 42, 0.9);
+    --color-floating-surface-hover: rgba(15, 23, 42, 1);
+    --color-overlay: rgba(15, 23, 42, 0.6);
   }
 }


### PR DESCRIPTION
## Summary
- add CSS custom properties that react to `prefers-color-scheme` so global text and surface colors follow the OS theme
- update the application shell styles to consume the shared variables for borders, backgrounds, and controls
- wire key theme configuration colors to the new CSS variables so context menus and overlays inherit the active scheme

## Testing
- npm --prefix frontend run lint *(fails: existing lint warnings/errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d787a0af78832daeb2b855c3bea4c3