### PR TITLE
Align modal and sidebar styling with system theme

### DIFF
--- a/frontend/src/components/ModalContainer.tsx
+++ b/frontend/src/components/ModalContainer.tsx
@@ -62,17 +62,19 @@ export const ModalHeader: React.FC<ModalHeaderProps> = ({
       alignItems: 'center',
       padding: '20px 24px',
       borderBottom: `1px solid ${theme.colors.border.light}`,
+      background: theme.components.modal.background,
+      color: theme.colors.text.primary,
       flexShrink: 0,
     }}>
       <div style={{ flex: 1 }}>
-        <h2 style={{ margin: 0, fontSize: 20, fontWeight: 600 }}>
+        <h2 style={{ margin: 0, fontSize: 20, fontWeight: 600, color: theme.colors.text.primary }}>
           {title}
         </h2>
         {subtitle && (
-          <p style={{ 
-            margin: '4px 0 0 0', 
-            fontSize: 14, 
-            color: theme.colors.text.secondary 
+          <p style={{
+            margin: '4px 0 0 0',
+            fontSize: 14,
+            color: theme.colors.text.secondary
           }}>
             {subtitle}
           </p>

--- a/frontend/src/config/theme.ts
+++ b/frontend/src/config/theme.ts
@@ -49,7 +49,7 @@ export const theme = {
       default: withCssVar('--color-border-subtle', colors.gray[300]),
       light: withCssVar('--color-border-subtle', colors.gray[200]),
       dark: withCssVar('--color-border-strong', colors.legacy.borderDefault),
-      active: colors.primary[500],
+      active: withCssVar('--color-accent', colors.primary[500]),
       expanded: colors.warning[700],
       error: colors.danger[500],
     },
@@ -59,7 +59,7 @@ export const theme = {
       secondary: withCssVar('--color-text-secondary', colors.gray[600]),
       muted: withCssVar('--color-text-secondary', colors.legacy.nodeDefault),
       inverse: withCssVar('--color-text-inverse', colors.legacy.white),
-      disabled: colors.gray[300],
+      disabled: withCssVar('--color-text-disabled', colors.gray[400]),
       error: colors.danger[600],
       success: colors.success[600],
     },
@@ -116,7 +116,7 @@ export const theme = {
         unknownText: '#6b7280',
       },
       button: {
-        primary: '#3b82f6',
+        primary: withCssVar('--color-accent', '#3b82f6'),
         secondary: 'transparent',
         success: '#10b981',
         warning: '#f59e0b',
@@ -227,8 +227,8 @@ export const theme = {
       borderRadius: radius.base,
       item: {
         padding: spacing.scale(2), // 8px
-        disabledColor: colors.gray[300],
-        shortcutColor: colors.legacy.nodeDefault,
+        disabledColor: withCssVar('--color-text-disabled', colors.gray[400]),
+        shortcutColor: withCssVar('--color-text-secondary', colors.legacy.nodeDefault),
         fontSize: fontSize.sm,
       },
     },
@@ -260,12 +260,12 @@ export const theme = {
       },
       tab: {
         active: {
-          background: colors.gray[100],
-          borderColor: colors.primary[500],
+          background: withCssVar('--color-surface-active', colors.gray[100]),
+          borderColor: withCssVar('--color-accent', colors.primary[500]),
         },
         inactive: {
-          background: 'transparent',
-          borderColor: 'transparent',
+          background: withCssVar('--color-surface-muted', colors.gray[50]),
+          borderColor: withCssVar('--color-border-subtle', colors.gray[200]),
         },
       },
     },
@@ -297,13 +297,13 @@ export const theme = {
       },
       tab: {
         active: {
-          background: colors.gray[100],
-          borderColor: colors.primary[500],
+          background: withCssVar('--color-surface-active', colors.gray[100]),
+          borderColor: withCssVar('--color-accent', colors.primary[500]),
           fontWeight: 600,
         },
         inactive: {
-          background: 'transparent',
-          borderColor: 'transparent',
+          background: withCssVar('--color-surface-muted', colors.gray[50]),
+          borderColor: withCssVar('--color-border-subtle', colors.gray[200]),
           fontWeight: 400,
         },
       },

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -12,17 +12,22 @@
   --color-bg-secondary: #f3f4f6;
   --color-surface-elevated: #f8f9fa;
   --color-surface-hover: #e9ecef;
+  --color-surface-muted: #eef2ff;
+  --color-surface-active: #dbeafe;
   --color-border-subtle: #e5e7eb;
   --color-border-strong: #cbd5e1;
   --color-text-primary: #213547;
   --color-text-secondary: #475569;
-  --color-text-inverse: #0f172a;
-  --color-link: #646cff;
-  --color-link-hover: #535bf2;
+  --color-text-disabled: #94a3b8;
+  --color-text-inverse: #f8fafc;
+  --color-link: #2563eb;
+  --color-link-hover: #1d4ed8;
   --color-button-bg: #f9f9f9;
   --color-floating-surface: rgba(255, 255, 255, 0.95);
   --color-floating-surface-hover: rgba(255, 255, 255, 1);
   --color-overlay: rgba(15, 23, 42, 0.45);
+  --color-accent: #2563eb;
+  --color-accent-contrast: #f8fafc;
 }
 
 a {
@@ -80,16 +85,21 @@ button:hover {
     --color-bg-secondary: #111827;
     --color-surface-elevated: #1f2937;
     --color-surface-hover: #273449;
+    --color-surface-muted: rgba(148, 163, 184, 0.12);
+    --color-surface-active: rgba(96, 165, 250, 0.2);
     --color-border-subtle: rgba(148, 163, 184, 0.35);
-    --color-border-strong: rgba(148, 163, 184, 0.55);
+    --color-border-strong: rgba(148, 163, 184, 0.6);
     --color-text-primary: #e2e8f0;
     --color-text-secondary: #cbd5f5;
-    --color-text-inverse: #0f172a;
-    --color-link: #a5b4fc;
-    --color-link-hover: #c7d2fe;
+    --color-text-disabled: rgba(148, 163, 184, 0.6);
+    --color-text-inverse: #f8fafc;
+    --color-link: #93c5fd;
+    --color-link-hover: #bfdbfe;
     --color-button-bg: rgba(148, 163, 184, 0.16);
     --color-floating-surface: rgba(15, 23, 42, 0.9);
     --color-floating-surface-hover: rgba(15, 23, 42, 1);
     --color-overlay: rgba(15, 23, 42, 0.6);
+    --color-accent: #60a5fa;
+    --color-accent-contrast: #0b1120;
   }
 }

--- a/frontend/src/utils/styleUtils.ts
+++ b/frontend/src/utils/styleUtils.ts
@@ -51,6 +51,7 @@ export const buildModalStyle = (options: {
   padding: theme.components.modal.padding,
   width: options.width || 'auto',
   maxWidth: options.maxWidth || '90vw',
+  color: theme.colors.text.primary,
   zIndex: options.zIndex || theme.zIndex.modal,
 });
 
@@ -135,6 +136,7 @@ export const buildDrawerStyle = () => css({
   background: theme.components.drawer.background,
   borderLeft: `1px solid ${theme.components.drawer.border}`,
   boxShadow: theme.components.drawer.shadow,
+  color: theme.colors.text.primary,
   zIndex: theme.zIndex.modal,
 });
 
@@ -153,13 +155,15 @@ export const buildDrawerTabStyle = (isActive: boolean) => css({
   flex: 1,
   padding: `${theme.components.drawer.header.padding}px`,
   border: 'none',
-  background: isActive 
-    ? theme.components.drawer.tab.active.background 
+  background: isActive
+    ? theme.components.drawer.tab.active.background
     : theme.components.drawer.tab.inactive.background,
   cursor: 'pointer',
-  borderBottom: `2px solid ${isActive 
-    ? theme.components.drawer.tab.active.borderColor 
+  borderBottom: `2px solid ${isActive
+    ? theme.components.drawer.tab.active.borderColor
     : theme.components.drawer.tab.inactive.borderColor}`,
+  color: isActive ? theme.colors.text.primary : theme.colors.text.secondary,
+  transition: 'background 0.2s ease, color 0.2s ease',
 });
 
 /**
@@ -168,16 +172,18 @@ export const buildDrawerTabStyle = (isActive: boolean) => css({
 export const buildTabStyle = (isActive: boolean) => css({
   padding: '8px 16px',
   border: 'none',
-  background: isActive 
-    ? theme.components.settingsModal.tab.active.background 
+  background: isActive
+    ? theme.components.settingsModal.tab.active.background
     : theme.components.settingsModal.tab.inactive.background,
   cursor: 'pointer',
-  fontWeight: isActive 
-    ? theme.components.settingsModal.tab.active.fontWeight 
+  fontWeight: isActive
+    ? theme.components.settingsModal.tab.active.fontWeight
     : theme.components.settingsModal.tab.inactive.fontWeight,
-  borderBottom: `2px solid ${isActive 
-    ? theme.components.settingsModal.tab.active.borderColor 
+  borderBottom: `2px solid ${isActive
+    ? theme.components.settingsModal.tab.active.borderColor
     : theme.components.settingsModal.tab.inactive.borderColor}`,
+  color: isActive ? theme.colors.text.primary : theme.colors.text.secondary,
+  transition: 'background 0.2s ease, color 0.2s ease',
 });
 
 /**


### PR DESCRIPTION
## Summary
- extend the global CSS variables to cover accent, disabled, and surface states for both light and dark themes
- have modal, drawer, and tab styles consume the updated theme tokens so overlays, tabs, and text inherit the correct colors
- ensure modal headers and contextual UI elements pick up the themed text colors for consistent contrast

## Testing
- `npm run lint` *(fails: existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d79e52d564832d89d64749179abcfc