### PR TITLE
Improve Admin Tools button contrast across themes

### DIFF
--- a/frontend/src/components/AdminButton.tsx
+++ b/frontend/src/components/AdminButton.tsx
@@ -4,6 +4,10 @@ import { useUIContext } from '../hooks/useUI';
 const AdminButton: React.FC = () => {
   const { openAdminModal } = useUIContext();
 
+  const accentColor = 'var(--color-accent, #2563eb)';
+  const accentHoverColor = 'color-mix(in srgb, var(--color-accent, #2563eb) 85%, black)';
+  const accentContrastColor = 'var(--color-accent-contrast, #f8fafc)';
+
   return (
     <button
       onClick={openAdminModal}
@@ -13,9 +17,9 @@ const AdminButton: React.FC = () => {
         left: 20,
         zIndex: 1000,
         padding: '12px 16px',
-        background: '#374151',
-        color: 'white',
-        border: 'none',
+        background: accentColor,
+        color: accentContrastColor,
+        border: '1px solid var(--color-border-strong, rgba(148, 163, 184, 0.35))',
         borderRadius: 8,
         fontSize: 14,
         fontWeight: 500,
@@ -24,21 +28,21 @@ const AdminButton: React.FC = () => {
         display: 'flex',
         alignItems: 'center',
         gap: 8,
-        transition: 'all 0.2s ease',
+        transition: 'transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease',
       }}
       onMouseEnter={(e) => {
-        e.currentTarget.style.background = '#1f2937';
+        e.currentTarget.style.background = accentHoverColor;
         e.currentTarget.style.transform = 'translateY(-2px)';
         e.currentTarget.style.boxShadow = '0 6px 16px rgba(0, 0, 0, 0.2)';
       }}
       onMouseLeave={(e) => {
-        e.currentTarget.style.background = '#374151';
+        e.currentTarget.style.background = accentColor;
         e.currentTarget.style.transform = 'translateY(0)';
         e.currentTarget.style.boxShadow = '0 4px 12px rgba(0, 0, 0, 0.15)';
       }}
       title="Open Admin Tools"
     >
-      <span style={{ fontSize: 16 }}>🔧</span>
+      <span style={{ fontSize: 16, color: accentContrastColor }}>🔧</span>
       Admin Tools
     </button>
   );


### PR DESCRIPTION
## Summary
- update the Admin Tools floating button to use theme color variables
- ensure text and icon colors maintain contrast in light and dark modes
- refine hover state styling to derive from the base accent color

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68d84743e470832db6dbf4aa5a75eadc