### PR TITLE
Allow admin modal access without API key gate

### DIFF
--- a/frontend/src/context/UIContext.tsx
+++ b/frontend/src/context/UIContext.tsx
@@ -23,7 +23,6 @@ export const UIProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
   const [editNodeData, setEditNodeData] = useState<NodeData | undefined>(undefined);
   const [settingsModalOpen, setSettingsModalOpen] = useState(false);
   const [adminModalOpen, setAdminModalOpen] = useState(false);
-  const [adminAuthenticated, setAdminAuthenticated] = useState(false);
   const [systemStatus, setSystemStatus] = useState<SystemStatus | null>(null);
   const lastOpenTimeRef = useRef<number>(0);
 
@@ -78,16 +77,6 @@ export const UIProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
     setAdminModalOpen(false);
   };
 
-  const authenticateAdmin = (): boolean => {
-    // Store admin key in memory only (not localStorage for security)
-    setAdminAuthenticated(true);
-    return true;
-  };
-
-  const logoutAdmin = () => {
-    setAdminAuthenticated(false);
-  };
-
   // System status functions
   const refreshSystemStatus = async () => {
     try {
@@ -114,11 +103,8 @@ export const UIProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
         openSettingsModal,
         closeSettingsModal,
         adminModalOpen,
-        adminAuthenticated,
         openAdminModal,
         closeAdminModal,
-        authenticateAdmin,
-        logoutAdmin,
         systemStatus,
         refreshSystemStatus,
       }}

--- a/frontend/src/context/contexts.ts
+++ b/frontend/src/context/contexts.ts
@@ -83,13 +83,10 @@ interface UIContextValue {
   settingsModalOpen: boolean;
   openSettingsModal: () => void;
   closeSettingsModal: () => void;
-  // Admin modal and authentication
+  // Admin modal
   adminModalOpen: boolean;
-  adminAuthenticated: boolean;
   openAdminModal: () => void;
   closeAdminModal: () => void;
-  authenticateAdmin: () => boolean;
-  logoutAdmin: () => void;
   // System status
   systemStatus: SystemStatus | null;
   refreshSystemStatus: () => Promise<void>;


### PR DESCRIPTION
## Summary
- remove the UI context auth flags so the admin modal no longer requires a stored API key to open
- update the admin modal to offer inline key configuration, show success/placeholder banners, and guard admin tools until a key is provided
- refresh the admin modal unit tests to cover the new key management flow and tab rendering

## Testing
- npx vitest run tests/unit/components/AdminModal.test.tsx

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69119b374600832d99019340aa002e5e)